### PR TITLE
URLs are case sensitive

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv=refresh content=0;url=Gluster/index.html>
+<meta http-equiv=refresh content=0;url=gluster/index.html>


### PR DESCRIPTION
The gluster directory has a lowercase g. You're redirecting to an uppercase one.

Browsing to http://cholcombe973.github.io/Gluster/gluster/index.html manually works.
