### PR TITLE
Update uuid to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ serde_derive = "~1.0"
 serde_json = "~1.0"
 serde-xml-rs = "~0.2"
 unix_socket = "~0.5"
-uuid = {version = "~0.5", features = ["v4", "use_std", "serde"]}
+uuid = {version = "0.6", features = ["v4", "std", "serde"]}


### PR DESCRIPTION
Hey

Updating this crate to 0.6 since the new release is out. There are no further changes required.

Also `with_std` was changed to `std` in this release.